### PR TITLE
Add meta tags and stylesheet link to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,12 @@
+<!DOCTYPE html>
+<html lang="en"> <!-- for other languages and translating -->
 <head>
-<title>luphoria</title>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/rhenryw/one.css@main/dist/one.light.min.css"> <!-- lightweight, dark/light compatible stylesheet -->
-<meta name="title" content="luphoria" /> <!-- for discord or twitter -->
-<meta name="description" content="info, contact, and more!" /> <!-- I don't really know what to put here -->
+    <meta charset="UTF-8" /> <!-- in case of an older browser trying ASCII or latin-1 -->
+    <meta name="viewport" content="width=device-width, initial-scale=1" /> <!-- redundancy, but good practice -->
+    <title>luphoria</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/rhenryw/one.css@main/dist/one.light.min.css"> <!-- lightweight, dark/light compatible stylesheet -->
+    <meta name="title" content="luphoria" /> <!-- for discord or twitter -->
+    <meta name="description" content="info, contact, and more!" /> <!-- I don't really know what to put here -->
 </head>
 <body>
     <h1>luphoria</h1>
@@ -19,3 +23,4 @@
     <br />
     Milwaukee, WI
 </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,8 @@
 <head>
 <title>luphoria</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/rhenryw/one.css@main/dist/one.min.css"> <!-- lightweight, dark/light compatible stylesheet -->
+<meta name="title" content="luphoria" /> <!-- for discord or twitter -->
+<meta name="description" content="info, contact, and more!" /> <!-- I don't really know what to put here -->
 </head>
 <body>
     <h1>luphoria</h1>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <head>
 <title>luphoria</title>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/rhenryw/one.css@main/dist/one.min.css"> <!-- lightweight, dark/light compatible stylesheet -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/rhenryw/one.css@main/dist/one.light.min.css"> <!-- lightweight, dark/light compatible stylesheet -->
 <meta name="title" content="luphoria" /> <!-- for discord or twitter -->
 <meta name="description" content="info, contact, and more!" /> <!-- I don't really know what to put here -->
 </head>


### PR DESCRIPTION
Hey! I went to your website on my system, and couldn't read any of the text.

Due to light/dark mode on modern browsers, it makes it unreadable or the same color as the background.

I opened a pr to add a stylesheet, [one.css](https://github.com/rhenryw/one.css/) which supports light/dark mode based on user's browser settings. It's pretty light (I think 3kb over cdn?) and just makes it readable. I also added simple metadata for social services.

Currenly it has a little bit of a high LCP (comparitavley, still very short) of 1s

If you want to save EVEN MORE (if you care) then instead of using the CDN download it from https://github.com/rhenryw/one.css/releases/download/latest/one.light.min.css either upon build or however you do it and then link it with

```html
<link rel="stylesheet" href="one.light.min.css">
```

it should bring the load time down to 0.4 ish.

If you want EVEN smaller, copy the [RAW contents](https://raw.githubusercontent.com/rhenryw/one.css/refs/heads/main/dist/one.light.min.css) and paste it in the head as

```html
<style>
:root{color-scheme:light;--font-family: system-ui... (rest of raw)
</style>
```

and it will be like 0.2 again.